### PR TITLE
Algebraic effects

### DIFF
--- a/bluefin-internal/bluefin-internal.cabal
+++ b/bluefin-internal/bluefin-internal.cabal
@@ -77,7 +77,7 @@ library
     default-language: Haskell2010
     hs-source-dirs: src
     build-depends:
-      base >= 4.12 && < 4.20,
+      base >= 4.18 && < 4.20,
       unliftio-core < 0.3,
       transformers < 0.7,
       transformers-base < 0.5,
@@ -85,7 +85,11 @@ library
     ghc-options: -Wall
     exposed-modules:
       Bluefin.Internal,
-      Bluefin.Internal.Examples
+      Bluefin.Internal.Algae,
+      Bluefin.Internal.Algae.Cancellable,
+      Bluefin.Internal.DelCont,
+      Bluefin.Internal.Examples,
+      Bluefin.Internal.Exception.Dynamic
 
 test-suite bluefin-test
     import:           defaults

--- a/bluefin-internal/src/Bluefin/Internal/Algae.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Algae.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE
+  BangPatterns,
+  GADTs,
+  RankNTypes,
+  ScopedTypeVariables,
+  StandaloneKindSignatures,
+  TypeOperators #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | = Algebraic effects and named handlers
+module Bluefin.Internal.Algae
+  ( AEffect
+  , HandlerBody
+  , Handler
+  , handle
+  , call
+  ) where
+
+import Data.Kind (Type)
+import Bluefin.Internal (Eff, Effects, type (:&), type (:>))
+import Bluefin.Internal.DelCont
+
+-- | Algebraic effect.
+type AEffect = Type -> Type
+
+-- | Interpretation of an algebraic effect @f@: a function to handle the operations of @f@.
+type HandlerBody :: AEffect -> Effects -> Type -> Type
+type HandlerBody f ss a = (forall x. f x -> (x -> Eff ss a) -> Eff ss a)
+
+-- | Handler to call operations of the effect @f@.
+type Handler :: AEffect -> Effects -> Type
+data Handler f s where
+  Handler :: !(PromptTag ss a s) -> HandlerBody f ss a -> Handler f s
+
+-- | Handle operations of @f@.
+--
+-- === Warning for exception-like effects
+--
+-- If the handler might not call the continuation (like for an exception effect), and
+-- if the handled computation manages resources (e.g., opening files, transactions)
+-- prefer 'handle'' to trigger resource clean up with cancellable continuations.
+handle ::
+  HandlerBody f ss a ->
+  (forall s. Handler f s -> Eff (s :& ss) a) ->
+  Eff ss a
+handle h act = reset (\p -> act (Handler p h))
+
+-- | Call an operation of @f@.
+call :: s :> ss => Handler f s -> f a -> Eff ss a
+call (Handler p h) op = shift0 p (\k -> h op (k . pure))

--- a/bluefin-internal/src/Bluefin/Internal/Algae/Cancellable.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Algae/Cancellable.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE
+  BangPatterns,
+  GADTs,
+  RankNTypes,
+  ScopedTypeVariables,
+  StandaloneKindSignatures,
+  TypeOperators #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | = Algebraic effects and named handlers with cancellable continuations
+module Bluefin.Internal.Algae.Cancellable
+  ( AEffect
+  , HandlerBody
+  , Handler
+  , handle
+  , call
+  , continue
+  , discontinue
+  , discontinueIO
+  ) where
+
+import Control.Exception (Exception)
+import Data.Kind (Type)
+import Bluefin.Internal (Eff, Effects, IOE, type (:>), type (:&))
+import Bluefin.Internal.DelCont
+import Bluefin.Internal.Exception.Dynamic
+import Bluefin.Internal.Algae (AEffect)
+
+-- | Interpretation of an algebraic effect @f@: a function to handle the operations of @f@
+-- with cancellable continuations.
+type HandlerBody :: Effects -> AEffect -> Effects -> Type -> Type
+type HandlerBody ex f ss a = (forall x ss0. ex :> ss0 => f x -> (Eff ss0 x -> Eff ss a) -> Eff ss a)
+
+-- | Handler to call operations of the effect @f@ with cancellable continuations.
+type Handler :: Effects -> AEffect -> Effects -> Type
+data Handler ex f s where
+  Handler :: !(PromptTag ss a s) -> HandlerBody ex f ss a -> Handler ex f s
+
+-- | Handle operations of @f@ with cancellable continuations.
+--
+-- The handle for exceptions (first argument) is only there to guide type inference.
+-- it can be either 'IOE' or 'DynExn'.
+handle ::
+  h ex ->
+  HandlerBody ex f ss a ->
+  (forall s. Handler ex f s -> Eff (s :& ss) a) ->
+  Eff ss a
+handle _ h act = reset (\p -> act (Handler p h))
+
+-- | Call an operation of @f@ with cancellable continuations.
+call :: (ex :> es, s :> es) => Handler ex f s -> f a -> Eff es a
+call (Handler p h) op = shift0 p (\k -> h op k)
+
+-- | Resume a cancellable continuation with a result.
+--
+-- In other words, this converts a cancellable continuation to a simple continuation.
+continue :: (Eff ss0 b -> Eff ss a) -> b -> Eff ss a
+continue k = k . pure
+
+-- | Cancel a continuation: resume by throwing a (dynamic) exception.
+discontinue :: (Exception e, ex :> es0) => DynExn ex -> (Eff es0 b -> Eff es a) -> e -> Eff es a
+discontinue ex k e = k (throw ex e)
+
+-- | 'discontinue' with an 'IOE' handle instead of the more restrictive 'DynExn'.
+--
+-- Note that different outcomes are possible depending on your handled computation.
+-- Be sure to handle them appropriately.
+--
+-- - A common situation is that the continuation will rethrow the initial exception,
+--   then you can just catch it.
+-- - The continuation may throw a different exception, so you should be
+--   careful to catch the right exception.
+-- - The continuation may also catch your exception and terminate normally
+--   with a result of type @a@.
+discontinueIO :: (Exception e, io :> es0) => IOE io -> (Eff es0 b -> Eff es a) -> e -> Eff es a
+discontinueIO io = discontinue (ioeToDynExn io)

--- a/bluefin-internal/src/Bluefin/Internal/DelCont.hs
+++ b/bluefin-internal/src/Bluefin/Internal/DelCont.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE
+  BangPatterns,
+  MagicHash,
+  RankNTypes,
+  ScopedTypeVariables,
+  StandaloneKindSignatures,
+  TypeOperators,
+  UnboxedTuples #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | = Delimited continuations
+module Bluefin.Internal.DelCont
+  ( PromptTag
+  , reset
+  , shift0
+  ) where
+
+import Data.Kind (Type)
+import GHC.Exts (State#, RealWorld, PromptTag#, prompt#, control0#, newPromptTag#)
+import GHC.IO (IO(IO))
+import Bluefin.Internal (Eff(..), Effects, type (:&), type (:>))
+
+-- | Tag for a prompt of type @Eff ss a@ and scope @s@.
+type PromptTag :: Effects -> Type -> Effects -> Type
+data PromptTag ss a s = PromptTag (PromptTag# a)
+
+unsafeMkEff :: (State# RealWorld -> (# State# RealWorld , a #)) -> Eff ss a
+unsafeMkEff f = UnsafeMkEff (IO f)
+
+unsafeRunEff :: Eff ss a -> State# RealWorld -> (# State# RealWorld , a #)
+unsafeRunEff (UnsafeMkEff (IO f)) = f
+
+-- | Run the enclosed computation under a prompt of type @Eff ss a@.
+--
+-- @
+-- f : forall s. 'PromptTag' ss a s -> 'Eff' (s ':&' ss) a
+-- -------------------------------------------------
+-- 'reset' (\\t -> f t) : 'Eff' ss a
+-- @
+--
+-- The enclosed computation @f@ is given a tag which identifies that prompt
+-- and remembers its type.
+-- The scope parameter @s@ prevents the tag from being used outside of the
+-- computation.
+--
+-- A prompt ('reset') delimits a slice of the call stack (or evaluation context),
+-- which can be captured with 'shift0'. This slice, a continuation,
+-- becomes a function of type @Eff ss0 b -> Eff ss a@ (where @Eff ss0 b@ is the
+-- result type of 'shift0' at its calling site).
+-- Calling the continuation restores the slice on the stack.
+reset :: forall a ss.
+  (forall s. PromptTag ss a s -> Eff (s :& ss) a) ->
+  Eff ss a
+reset f = unsafeMkEff (\z0 -> case newPromptTag# z0 of
+    (# z1, tag #) -> prompt# tag (unsafeRunEff (f (PromptTag tag))) z1)
+
+-- | Capture the continuation up to the tagged prompt.
+--
+-- @
+-- _ : s :> ss0
+-- t : 'PromptTag' ss a s
+-- f : ('Eff' ss0 b -> 'Eff' ss a) -> 'Eff' ss a
+-- ---------------------------------------
+-- 'shift0' t (\\k -> f k) : 'Eff' ss0 b
+-- @
+--
+-- The prompt ('reset') is reinserted on the stack when the continuation is called:
+--
+-- @
+-- 'reset' (\\t -> C ('shift0' t f)) = f (\\x -> 'reset' (\\t -> C x))
+-- @
+shift0 :: forall s a b ss ss0.
+  s :> ss0 =>
+  PromptTag ss a s ->
+  ((Eff ss0 b -> Eff ss a) -> Eff ss a) ->
+  Eff ss0 b
+shift0 (PromptTag tag) f = unsafeMkEff (\z0 ->
+  control0# tag (\k# ->
+    unsafeRunEff (f (unsafeMkEff . prompt# tag . k# . unsafeRunEff))) z0)

--- a/bluefin-internal/src/Bluefin/Internal/Exception/Dynamic.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Exception/Dynamic.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE
+  KindSignatures,
+  ScopedTypeVariables,
+  TypeOperators #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | = Dynamic exceptions
+module Bluefin.Internal.Exception.Dynamic
+  ( DynExn
+  , ioeToDynExn
+  , throw
+  , catch
+  , bracket
+  , finally
+  , onException
+  , throwIO
+  , catchIO
+  ) where
+
+import qualified Control.Exception as E
+import Bluefin.Internal (Eff(..), Effects, IOE, type (:>))
+
+-- | Capability to throw dynamic exceptions.
+data DynExn (ex :: Effects) = DynExn
+
+-- | Refine an 'IOE' capability to a 'DynExn'.
+ioeToDynExn :: IOE io -> DynExn io
+ioeToDynExn _ = DynExn
+
+throw :: (E.Exception e, ex :> es) => DynExn ex -> e -> Eff es a
+throw _ e = UnsafeMkEff (E.throwIO e)
+
+catch :: (E.Exception e, ex :> es) => DynExn ex -> Eff es a -> (e -> Eff es a) -> Eff es a
+catch _ m h = UnsafeMkEff (E.catch (unsafeUnEff m) (unsafeUnEff . h))
+
+-- | @'bracket' ex acquire release run@: @acquire@ a resource, @run@ a computation depending on it,
+-- and finally @relase@ the resource even if @run@ threw an exception.
+bracket :: ex :> es => DynExn ex -> Eff es a -> (a -> Eff es ()) -> (a -> Eff es b) -> Eff es b
+bracket ex acquire release run = do
+  a <- acquire
+  finally ex (run a) (release a)
+
+-- | @'finally' ex run cleanup@: @run@ a computation, then @cleanup@ even if
+-- @run@ threw an exception.
+finally :: ex :> es => DynExn ex -> Eff es a -> Eff es () -> Eff es a
+finally ex run cleanup =
+  onException ex run cleanup   -- if run throws an exception, then only this cleanup will run
+    <* cleanup                 -- if run does not throw, then only this cleanup will run
+
+-- | @'onException' ex run cleanup@: @run@ a computation, and if an exception is thrown,
+-- @cleanup@, then rethrow the exception.
+onException :: ex :> es => DynExn ex -> Eff es a -> Eff es () -> Eff es a
+onException ex run cleanup = catch ex run (\(e :: E.SomeException) -> cleanup >> throw ex e)
+
+-- | 'throw' with an 'IOE' capability.
+throwIO :: (E.Exception e, io :> es) => IOE io -> e -> Eff es a
+throwIO io = throw (ioeToDynExn io)
+
+-- | 'catch' with an 'IOE' capability.
+catchIO :: (E.Exception e, io :> es) => IOE io -> Eff es a -> (e -> Eff es a) -> Eff es a
+catchIO io = catch (ioeToDynExn io)

--- a/bluefin/bluefin.cabal
+++ b/bluefin/bluefin.cabal
@@ -21,11 +21,15 @@ library
       NoImplicitPrelude
     exposed-modules:
       Bluefin,
+      Bluefin.Algae,
+      Bluefin.Algae.Cancellable,
       Bluefin.Compound,
       Bluefin.Coroutine,
+      Bluefin.DelCont,
       Bluefin.EarlyReturn,
       Bluefin.Eff,
       Bluefin.Exception,
+      Bluefin.Exception.Dynamic,
       Bluefin.IO,
       Bluefin.Jump,
       Bluefin.Reader,

--- a/bluefin/src/Bluefin/Algae.hs
+++ b/bluefin/src/Bluefin/Algae.hs
@@ -1,0 +1,73 @@
+-- | = Algebraic effects and named handlers
+--
+-- Algebraic effect handlers are a powerful framework for
+-- user-defined effects with a simple equational intuition.
+--
+-- Algebraic effect handlers are expressive enough to define various effects
+-- from scratch. Otherwise, implementing 'runState' for example requires
+-- mutable references (@IORef@), relying on @IO@'s built-in statefulness.
+-- In terms of pure expressiveness, delimited continuations are all you need.
+--
+-- An "algebraic effect" is a signature for a set of operations which we
+-- represent with a GADT. For example, the "state effect" @State s@ contains
+-- two operations: @Get@ takes no parameter and returns a value of type @s@,
+-- and @Put@ takes a value of type @s@ and returns @()@. The constructors
+-- @Get@ and @Put@ are "uninterpreted operations": they only describe the types
+-- of arguments and results, with no intrinsic meaning.
+--
+-- @
+-- data State s r where
+--   Get :: State s s
+--   Put :: s -> State s ()
+-- @
+--
+-- Below is an example of a stateful computation: a term of some type @'Eff' zz a@ with
+-- a state handler @h :: 'Handler' (State s) z@ in scope (@z :> zz@).
+-- The @State@ operations can be called using 'call' and the state handler @h@.
+--
+-- @
+-- -- Increment a counter and return its previous value.
+-- incr :: z :> zz => Handler (State Int) z -> Eff zz Int
+-- incr h = do
+--     n <- get
+--     put (n + 1)
+--     pure n
+--   where
+--     get = call h Get
+--     put s = call h (Put s)
+-- @
+--
+-- We handle the state effect by giving an interpretation of the @Get@ and @Put@
+-- operations, as a function @f :: 'HandlerBody' (State s) zz a@.
+--
+-- To 'call' @Get@ or @Put@ is to call the function @f@ supplied by 'handle'.
+-- The following equations show how 'handle' propagates an interpretation
+-- @f@ throughout a computation that calls @Get@ and @Put@:
+--
+-- @
+-- handle f (\\h -> call h Get     >>= k h) = f Get     (handle f (\\h -> k h))
+-- handle f (\\h -> call h (Put s) >>= k h) = f (Put s) (handle f (\\h -> k h))
+-- handle f (\\h -> pure r) = pure r
+-- @
+--
+-- With those equations, @'handle' f@ applied to the above @incr@ simplifies to:
+--
+-- @
+-- 'handle' f incr =
+--   f Get \\n ->
+--   f (Put (n+1)) \\() ->
+--   pure n
+-- @
+--
+-- === References
+--
+-- - <https://www.microsoft.com/en-us/research/uploads/prod/2021/05/namedh-tr.pdf First-class names for effect handlers> (2021) by Ningning Xie, Youyou Cong, and Daan Leijen.
+module Bluefin.Algae
+  ( AEffect
+  , HandlerBody
+  , Handler
+  , handle
+  , call
+  ) where
+
+import Bluefin.Internal.Algae

--- a/bluefin/src/Bluefin/Algae/Cancellable.hs
+++ b/bluefin/src/Bluefin/Algae/Cancellable.hs
@@ -1,0 +1,58 @@
+-- | = Algebraic effects and named handlers with cancellable continuations
+--
+-- See "Bluefin.Algae" for a general exposition on effect handlers.
+-- "Bluefin.Algae" and "Bluefin.Algae.Cancellable" use the same names
+-- so they should not be imported unqualified at the same time.
+--
+-- Cancellable continuations are useful to work with native exception handlers
+-- such as 'Control.Exception.bracket' and other resource-management schemes à
+-- la @resourcet@.
+--
+-- Cancellable continuations should be called exactly once (via 'continue' or 'discontinue'):
+-- - at least once to ensure resources are eventually freed (no leaks);
+-- - at most once to avoid use-after-free errors.
+--
+-- Enforcing this requirement with linear types would be a welcome contribution.
+--
+-- === Example
+--
+-- ==== Problem
+--
+-- Given 'Bluefin.Exception.Dynamic.bracket' and a @Fail@ effect,
+-- the simple 'Bluefin.Algae.handle' from "Bluefin.Algae" may cause resource leaks:
+--
+-- @
+-- 'Bluefin.Algae.handle' (\\_e _k -> pure Nothing)
+--   ('Bluefin.Exception.Dynamic.bracket' ex acquire release (\\_ -> 'call' h Fail))
+-- @
+--
+-- @bracket@ is intended to ensure that the acquired resource is released even if the bracketed
+-- function throws an exception. However, when the @Fail@ operation is called, the handler
+-- @(\\_e _k -> pure Nothing)@ discards the continuation @_k@ which contains the
+-- exception handler installed by @bracket@.
+-- The resource leaks because @release@ will never be called.
+--
+-- ==== Solution
+--
+-- Using 'handle' from this module instead lets us cancel the continuation with 'discontinue'.
+-- Cancellable continuations require a 'DynExn' or 'IOE' handle.
+--
+-- @
+-- 'handle'' io (\\_e k ->
+--      try @CancelContinuation ('discontinueIO' k CancelContinuation) >> pure Nothing)
+--   ('Bluefin.Exception.Dynamic.bracket' acquire release (\\_ -> 'call' h Fail))
+--
+-- data CancelContinuation = CancelContinuation deriving (Show, Exception)
+-- @
+module Bluefin.Algae.Cancellable
+  ( AEffect
+  , HandlerBody
+  , Handler
+  , handle
+  , call
+  , continue
+  , discontinue
+  , discontinueIO
+  ) where
+
+import Bluefin.Internal.Algae.Cancellable

--- a/bluefin/src/Bluefin/DelCont.hs
+++ b/bluefin/src/Bluefin/DelCont.hs
@@ -1,0 +1,40 @@
+-- | = Delimited continuations
+--
+-- Native multi-prompt delimited continuations.
+-- These primitives let us manipulate slices of the call stack/evaluation
+-- context delimited by 'reset'.
+--
+-- This module serves as a foundation for algebraic effect handlers,
+-- a more structured interface for manipulating continuations and implementing
+-- user-defined effects.
+--
+-- The behavior of 'reset' and 'shift0' is summarized by the following equations:
+--
+-- @
+-- 'reset' (\\_ -> 'pure' x) = 'pure' x
+-- 'reset' (\\t -> C ('shift0' t f)) = f (\\x -> 'reset' (\\t -> C x))
+-- @
+--
+-- where @C@ is an evaluation context (in which @t@ may occur), i.e.,
+-- a term of the following form:
+--
+-- > C x ::= C x >>= k      -- for any function k
+-- >       | H (\h -> C x)  -- for any handler H ∈ { reset, (`runState` s), ... }
+-- >       | x
+--
+--
+-- This module ensures type safety. The rank-2 type of 'reset'
+-- guarantees that 'shift0' will always have a maching 'reset' on the stack.
+--
+-- === References
+--
+-- - <https://ghc-proposals.readthedocs.io/en/latest/proposals/0313-delimited-continuation-primops.html Delimited continuation primops> (GHC proposal, implemented in GHC 9.6.1).
+-- - <https://homes.luddy.indiana.edu/ccshan/recur/recur.pdf Shift to Control> (2004) by Chung-chieh Shan. The name 'shift0' follows the nomenclature in that paper.
+
+module Bluefin.DelCont
+  ( PromptTag
+  , reset
+  , shift0
+  ) where
+
+import Bluefin.Internal.DelCont

--- a/bluefin/src/Bluefin/Exception/Dynamic.hs
+++ b/bluefin/src/Bluefin/Exception/Dynamic.hs
@@ -1,0 +1,23 @@
+-- | = Dynamic exceptions
+--
+-- This is the vanilla exception mechanism from @IO@.
+-- Use this module to handle exceptions from external (non-bluefin) APIs.
+--
+-- This module also enables a style of resource management where clean up happens
+-- in exception handlers (e.g., using 'bracket', 'finally'). This is also compatible
+-- with algebraic effect handlers using cancellable continuations
+-- ("Bluefin.Algae.Cancellable").
+
+module Bluefin.Exception.Dynamic
+  ( DynExn
+  , ioeToDynExn
+  , throw
+  , catch
+  , bracket
+  , finally
+  , onException
+  , throwIO
+  , catchIO
+  ) where
+
+import Bluefin.Internal.Exception.Dynamic


### PR DESCRIPTION
Since `Bluefin.Eff` is just `IO`, it's quite feasible to adopt the delimited continuations primops from GHC 9.6 (base 4.18) in bluefin and do all of the algebraic effect machinery on top.

**Effects, now algebraic** Delimited continuations are the main difference between "bluefin/effectful effects" and "algebraic effects". While bluefin is an effect system, its expressiveness without delimited continuations is basically limited to what you call  `Coroutine`: all of the "effects" boil down to passing impure functions around (modulo some defunctionalization). Delimited continuations let you implement all of the existing effects and more from scratch, without any other form of impurity ("`IO`"):

- State without built-in `IORef`
- Exceptions without built-in `throw`/`catch`
- Nondeterminism, which is not present in `IO`
- Concurrency without built-in scheduler

(Some of these implementations can be found [in my experimental repo](https://github.com/Lysxia/toro/blob/d1a11bacaaae3aba2ee9516efb63cb67379ce728/src/Toro/BluefinLib.hs).)

(You might actually not want to implement all of your effects that way, `State` using delimited continuations seems not very efficient, and the dynamism of native exceptions has its uses (even in this very PR). Nondeterminism and concurrency (including first-class coroutines/generators) remain as newly achievable items with these delimited continuations/algebraic effects, so that's exciting.)

To be tested; but it compiles (with GHC 9.8 at least), so it must work, as the saying goes:

- Delimited continuations primops `Bluefin.DelCont`
- Algebraic effects `Bluefin.Algae` (sticking with the oceanic theme)

Taking inspiration from OCaml, I implemented a further extension with cancellable continuations:

- Dynamic exceptions (that is, port `Control.Exception` to bluefin, without any of the existing static exception's scoping shenanigans) `Bluefin.Exception.Dynamic`
- Algebraic effects with cancellable continuations `Bluefin.Algae.Cancellable`

Cf the headers of those respective modules (not the internal ones) for details.

Would you like to include this in bluefin?

Possible reservations are that it's a lot of untested code, and that it requires GHC 9.6 (base 4.18; whereas the current bound allows base 4.12).

At a minimum, the dynamic exceptions module seems useful independently of the rest.