### PR TITLE
Add support for custom handles

### DIFF
--- a/bluefin-internal/bluefin-internal.cabal
+++ b/bluefin-internal/bluefin-internal.cabal
@@ -85,6 +85,7 @@ library
     ghc-options: -Wall
     exposed-modules:
       Bluefin.Internal,
+      Bluefin.Internal.Handle,
       Bluefin.Internal.Examples
 
 test-suite bluefin-test

--- a/bluefin-internal/src/Bluefin/Internal.hs
+++ b/bluefin-internal/src/Bluefin/Internal.hs
@@ -159,6 +159,9 @@ insertFirst = weakenEff (drop (eq (# #)))
 insertSecond :: Eff (c1 :& b) r -> Eff (c1 :& (c2 :& b)) r
 insertSecond = weakenEff (b (drop (eq (# #))))
 
+insertManySecond :: b :> c => Eff (c1 :& b) r -> Eff (c1 :& c) r
+insertManySecond = weakenEff (bimap has has)
+
 assoc1Eff :: Eff ((a :& b) :& c) r -> Eff (a :& (b :& c)) r
 assoc1Eff = weakenEff (assoc1 (# #))
 

--- a/bluefin-internal/src/Bluefin/Internal.hs
+++ b/bluefin-internal/src/Bluefin/Internal.hs
@@ -246,6 +246,11 @@ class IsHandle (h :: Effects -> Type) where
   -- other handles.
   mapHandle :: (e :> es) => h e -> h es
 
+class IsHandle1 (h :: Effects -> Effects -> Type) where
+  -- | Used to create compound effects, i.e. handles that contain
+  -- other handles.
+  mapHandle1 :: (e :> es) => h e' e -> h e' es
+
 instance IsHandle (State s) where
   mapHandle (UnsafeMkState s) = UnsafeMkState s
 

--- a/bluefin-internal/src/Bluefin/Internal/Examples.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Examples.hs
@@ -4,7 +4,7 @@
 module Bluefin.Internal.Examples where
 
 import Bluefin.Internal hiding (w)
-import Bluefin.Internal.Handle (Handle, with)
+import Bluefin.Internal.Handle (Handle, within)
 import Control.Exception (IOException)
 import qualified Control.Exception
 import Control.Monad (forever, unless, when)
@@ -602,7 +602,7 @@ runFileSystemPure' ex fs0 k =
                 writeFileImpl = \path contents ->
                   modify fs ((path, contents) :)
               }
-       in with fsh0 $ \fsh -> insertSecond (insertSecond (k fsh))
+       in within k fsh0
 
 action :: (e :> es) => FileSystem e -> Eff es String
 action fs = do

--- a/bluefin-internal/src/Bluefin/Internal/Examples.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Examples.hs
@@ -585,17 +585,18 @@ runFileSystemPure' ::
   Eff es r
 runFileSystemPure' ex fs0 k =
   evalState fs0 $ \fs ->
-    let fsh0 = MkFileSystem
-          { readFileImpl = \path -> do
-              fs' <- get fs
-              case lookup path fs' of
-                Nothing ->
-                  throw ex ("File not found: " <> path)
-                Just s -> pure s,
-            writeFileImpl = \path contents ->
-              modify fs ((path, contents) :)
-          }
-    in with fsh0 $ \fsh -> insertSecond (k fsh)
+    let fsh0 =
+          MkFileSystem
+            { readFileImpl = \path -> do
+                fs' <- get fs
+                case lookup path fs' of
+                  Nothing ->
+                    throw ex ("File not found: " <> path)
+                  Just s -> pure s,
+              writeFileImpl = \path contents ->
+                modify fs ((path, contents) :)
+            }
+     in with fsh0 $ \fsh -> insertSecond (k fsh)
 
 action :: (e :> es) => FileSystem e -> Eff es String
 action fs = do

--- a/bluefin-internal/src/Bluefin/Internal/Examples.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Examples.hs
@@ -520,25 +520,25 @@ exampleCounter6 = runPureEff $ yieldToList $ \y -> do
 
 -- FileSystem
 
-data FileSystem es = MkFileSystem
+data FileSystem e es = MkFileSystem
   { readFileImpl :: FilePath -> Eff es String,
     writeFileImpl :: FilePath -> String -> Eff es ()
   }
 
-instance IsHandle FileSystem where
-  mapHandle (MkFileSystem read write) = MkFileSystem (useImpl . read) (fmap useImpl . write)
+instance IsHandle1 FileSystem where
+  mapHandle1 (MkFileSystem read write) = MkFileSystem (useImpl . read) (fmap useImpl . write)
 
-readFile :: (e :> es) => FileSystem e -> FilePath -> Eff es String
+readFile :: (e :> es) => FileSystem e' e -> FilePath -> Eff es String
 readFile fs filepath = useImpl (readFileImpl fs filepath)
 
-writeFile :: (e :> es) => FileSystem e -> FilePath -> String -> Eff es ()
+writeFile :: (e :> es) => FileSystem e' e -> FilePath -> String -> Eff es ()
 writeFile fs filepath contents = useImpl (writeFileImpl fs filepath contents)
 
 runFileSystemPure ::
   (e1 :> es) =>
   Exception String e1 ->
   [(FilePath, String)] ->
-  (forall e2. FileSystem e2 -> Eff (e2 :& es) r) ->
+  (forall e2. FileSystem e' e2 -> Eff (e2 :& es) r) ->
   Eff es r
 runFileSystemPure ex fs0 k =
   evalState fs0 $ \fs ->
@@ -559,11 +559,11 @@ runFileSystemPure ex fs0 k =
           }
 
 runFileSystemIO ::
-  forall e1 e2 es r.
+  forall e1 e2 es r e'.
   (e1 :> es, e2 :> es) =>
   Exception String e1 ->
   IOE e2 ->
-  (forall e. FileSystem e -> Eff (e :& es) r) ->
+  (forall e. FileSystem e' e -> Eff (e :& es) r) ->
   Eff es r
 runFileSystemIO ex io k =
   useImplIn
@@ -605,7 +605,7 @@ runFileSystemPure' ex fs0 k =
               modify fs ((path, contents) :)
           }
 
-action :: (e :> es) => FileSystem e -> Eff es String
+action :: (e :> es) => FileSystem e' e -> Eff es String
 action fs = do
   file <- readFile fs "/dev/null"
   when (length file == 0) $ do
@@ -623,9 +623,9 @@ exampleRunFileSystemPure :: Either String String
 exampleRunFileSystemPure = runPureEff $ try $ \ex ->
   runFileSystemPure ex [("/dev/null", "")] action
 
--- exampleRunFileSystemPure' :: Either String String
--- exampleRunFileSystemPure' = runPureEff $ try $ \ex ->
---   runFileSystemPure' ex [("/dev/null", "")] action'
+exampleRunFileSystemPure' :: Either String String
+exampleRunFileSystemPure' = runPureEff $ try $ \ex ->
+  runFileSystemPure' ex [("/dev/null", "")] action'
 
 -- > exampleRunFileSystemPure
 -- Left "File not found: /tmp/doesn't exist"

--- a/bluefin-internal/src/Bluefin/Internal/Examples.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Examples.hs
@@ -611,6 +611,13 @@ action fs = do
     writeFile fs "/tmp/bluefin" "Hello!\n"
   readFile fs "/tmp/doesn't exist"
 
+action' :: e :> es => Handle FileSystem e -> Eff es String
+action' fs = do
+  file <- readFileImpl fs "/dev/null"
+  when (length file == 0) $ do
+    writeFileImpl fs "/tmp/bluefin" "Hello!\n"
+  readFileImpl fs "/tmp/doesn't exist"
+
 exampleRunFileSystemPure :: Either String String
 exampleRunFileSystemPure = runPureEff $ try $ \ex ->
   runFileSystemPure ex [("/dev/null", "")] action

--- a/bluefin-internal/src/Bluefin/Internal/Examples.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Examples.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE NoMonoLocalBinds #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 

--- a/bluefin-internal/src/Bluefin/Internal/Examples.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Examples.hs
@@ -623,6 +623,10 @@ exampleRunFileSystemPure :: Either String String
 exampleRunFileSystemPure = runPureEff $ try $ \ex ->
   runFileSystemPure ex [("/dev/null", "")] action
 
+-- exampleRunFileSystemPure' :: Either String String
+-- exampleRunFileSystemPure' = runPureEff $ try $ \ex ->
+--   runFileSystemPure' ex [("/dev/null", "")] action'
+
 -- > exampleRunFileSystemPure
 -- Left "File not found: /tmp/doesn't exist"
 

--- a/bluefin-internal/src/Bluefin/Internal/Examples.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Examples.hs
@@ -591,18 +591,18 @@ runFileSystemPure' ex fs0 k =
     -- This extra handler confirms that we can create our handle in
     -- the context of more than one handler
     evalState () $ \_ ->
-      let fsh0 =
-            MkFileSystem
-              { readFileImpl = \path -> do
-                  fs' <- get fs
-                  case lookup path fs' of
-                    Nothing ->
-                      throw ex ("File not found: " <> path)
-                    Just s -> pure s,
-                writeFileImpl = \path contents ->
-                  modify fs ((path, contents) :)
-              }
-       in within k fsh0
+      within
+        k
+        MkFileSystem
+          { readFileImpl = \path -> do
+              fs' <- get fs
+              case lookup path fs' of
+                Nothing ->
+                  throw ex ("File not found: " <> path)
+                Just s -> pure s,
+            writeFileImpl = \path contents ->
+              modify fs ((path, contents) :)
+          }
 
 action :: (e :> es) => FileSystem e -> Eff es String
 action fs = do

--- a/bluefin-internal/src/Bluefin/Internal/Examples.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Examples.hs
@@ -523,6 +523,9 @@ data FileSystem es = MkFileSystem
     writeFileImpl :: FilePath -> String -> Eff es ()
   }
 
+instance IsHandle FileSystem where
+  mapHandle (MkFileSystem read write) = MkFileSystem (useImpl . read) (fmap useImpl . write)
+
 readFile :: (e :> es) => FileSystem e -> FilePath -> Eff es String
 readFile fs filepath = useImpl (readFileImpl fs filepath)
 
@@ -596,7 +599,7 @@ exampleRunFileSystemIO = runEff $ \io -> try $ \ex ->
 -- \$ cat /tmp/bluefin
 -- Hello!
 
--- instance Handle example
+-- instance IsHandle example
 
 data Application e = MkApplication
   { queryDatabase :: String -> Int -> Eff e [String],
@@ -604,7 +607,7 @@ data Application e = MkApplication
     logger :: Stream String e
   }
 
-instance Handle Application where
+instance IsHandle Application where
   mapHandle
     MkApplication
       { queryDatabase = q,

--- a/bluefin-internal/src/Bluefin/Internal/Handle.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Handle.hs
@@ -18,7 +18,7 @@ where
 import Bluefin.Internal
   ( Eff,
     Effects,
-    IsHandle (..),
+    IsHandle1 (..),
     insertManySecond,
     mergeEff,
     type (:&),
@@ -66,7 +66,7 @@ type Sig = Effects -> Type
 -- get :: e0 :> e => 'Handle' (State s) e0 -> 'Eff' e s
 -- put :: e0 :> e => 'Handle' (State s) e0 -> s -> 'Eff' e ()
 -- @
-type Handle f e = (forall e1. (e :> e1) => f e1)
+type Handle f e = (forall e1. (e :> e1) => f e e1)
 
 -- | Create a 'Handle' @h@ with signature @f@, using the given implementation @impl@.
 --
@@ -74,19 +74,19 @@ type Handle f e = (forall e1. (e :> e1) => f e1)
 -- 'with' impl \\h -> ...
 -- @
 with ::
-  (IsHandle f) =>
+  (IsHandle1 f) =>
   -- | Implementation with effect @e@
-  f e ->
+  f e e ->
   (forall e0. Handle f e0 -> Eff (e0 :& e) a) ->
   Eff e a
-with handle action = mergeEff (action (mapHandle handle))
+with handle action = mergeEff (action (mapHandle1 handle))
 
 -- Internally, we just instantiate e0 with e.
 
 within ::
-  (IsHandle f, e :> es) =>
+  (IsHandle1 f, e :> es) =>
   (forall e0. Handle f e0 -> Eff (e0 :& e) r) ->
-  f es ->
+  f es es ->
   Eff es r
 within k fsh0 = with fsh0 (useImplWithin k)
 

--- a/bluefin-internal/src/Bluefin/Internal/Handle.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Handle.hs
@@ -34,9 +34,9 @@ import Bluefin.Internal (Eff, Effects, IsHandle(..), mergeEff, type (:&), type (
 --
 -- @
 -- type State :: Type -> 'Sig'
--- data State s m = MkState
---   { get :: m s
---   , put :: s -> m ()
+-- data State s e = MkState
+--   { get :: Eff e s
+--   , put :: s -> Eff e ()
 --   }
 -- @
 type Sig = Effects -> Type

--- a/bluefin-internal/src/Bluefin/Internal/Handle.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Handle.hs
@@ -14,7 +14,14 @@ module Bluefin.Internal.Handle
   )
 where
 
-import Bluefin.Internal (Eff, Effects, IsHandle (..), mergeEff, type (:&), type (:>))
+import Bluefin.Internal
+  ( Eff,
+    Effects,
+    IsHandle (..),
+    mergeEff,
+    type (:&),
+    type (:>),
+  )
 import Data.Kind (Type)
 
 -- | An effect signature declares a set of effectful operations.

--- a/bluefin-internal/src/Bluefin/Internal/Handle.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Handle.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE
-  KindSignatures,
-  RankNTypes,
-  TypeOperators #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Bluefin.Internal.Handle
   ( -- * Effect signatures
-    Sig
+    Sig,
 
     -- * Handle usage
-  , Handle
+    Handle,
 
     -- * Handle creation
-  , with
-  ) where
+    with,
+  )
+where
 
+import Bluefin.Internal (Eff, Effects, IsHandle (..), mergeEff, type (:&), type (:>))
 import Data.Kind (Type)
-import Bluefin.Internal (Eff, Effects, IsHandle(..), mergeEff, type (:&), type (:>))
 
 -- | An effect signature declares a set of effectful operations.
 --
@@ -57,16 +57,19 @@ type Sig = Effects -> Type
 -- get :: e0 :> e => 'Handle' (State s) e0 -> 'Eff' e s
 -- put :: e0 :> e => 'Handle' (State s) e0 -> s -> 'Eff' e ()
 -- @
-type Handle f e = (forall e1. e :> e1 => f e1)
+type Handle f e = (forall e1. (e :> e1) => f e1)
 
 -- | Create a 'Handle' @h@ with signature @f@, using the given implementation @impl@.
 --
 -- @
 -- 'with' impl \\h -> ...
 -- @
-with :: IsHandle f =>
-  f e ->  -- ^ Implementation with effect @e@
+with ::
+  (IsHandle f) =>
+  -- | Implementation with effect @e@
+  f e ->
   (forall e0. Handle f e0 -> Eff (e0 :& e) a) ->
   Eff e a
 with handle action = mergeEff (action (mapHandle handle))
+
 -- Internally, we just instantiate e0 with e.

--- a/bluefin-internal/src/Bluefin/Internal/Handle.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Handle.hs
@@ -6,28 +6,26 @@
 module Bluefin.Internal.Handle
   ( -- * Effect signatures
     Sig
-  , CovariantSig(..)
 
     -- * Handle usage
   , Handle
 
     -- * Handle creation
-  , HandleImpl
   , with
   ) where
 
 import Data.Kind (Type)
-import Bluefin.Internal (Eff, mergeEff, useImpl, type (:&), type (:>))
+import Bluefin.Internal (Eff, Effects, IsHandle(..), mergeEff, type (:&), type (:>))
 
 -- | An effect signature declares a set of effectful operations.
 --
 -- Concretely, it should be a record of functions parameterized by a monad
 -- which occurs in the codomain of every field.
 --
--- A handle of signature @f@ can be defined simply as a value of type @f (Eff s)@.
+-- A handle of signature @f@ can be defined simply as a value of type @f (Eff e)@.
 -- But to use it, a handle will have type @'Handle' f@ so that its operations
 -- can be invoked with different effect rows in 'Eff', as long as they contain
--- the row @s@ in the type of its original definition @f (Eff s)@.
+-- the row @e@ in the type of its original definition @f (Eff e)@.
 -- See 'Handle' and 'with' for more detaills.
 --
 -- === Example
@@ -41,14 +39,10 @@ import Bluefin.Internal (Eff, mergeEff, useImpl, type (:&), type (:>))
 --   , put :: s -> m ()
 --   }
 -- @
-type Sig = (Type -> Type) -> Type
+type Sig = Effects -> Type
 
--- | Effect signatures must be instances of this class: they are higher-order functors.
-class CovariantSig (f :: Sig) where
-  smap :: (forall x. m x -> n x) -> f m -> f n
-
--- | Handle of signature @f@ that can be used in an effectful computation @'Eff' s1@,
--- given a constraint @s :> s1@.
+-- | Handle of signature @f@ that can be used in an effectful computation @'Eff' e1@,
+-- given a constraint @e :> e1@.
 --
 -- === Example
 --
@@ -60,22 +54,19 @@ class CovariantSig (f :: Sig) where
 -- to the following types:
 --
 -- @
--- get :: z0 :> z => 'Handle' (State s) z0 -> 'Eff' z s
--- put :: z0 :> z => 'Handle' (State s) z0 -> s -> 'Eff' z ()
+-- get :: e0 :> e => 'Handle' (State s) e0 -> 'Eff' e s
+-- put :: e0 :> e => 'Handle' (State s) e0 -> s -> 'Eff' e ()
 -- @
-type Handle f s = (forall s1. s :> s1 => f (Eff s1))
-
--- | Handle implementation of signature @f@.
-type HandleImpl f s = f (Eff s)
+type Handle f e = (forall e1. e :> e1 => f e1)
 
 -- | Create a 'Handle' @h@ with signature @f@, using the given implementation @impl@.
 --
 -- @
 -- 'with' impl \\h -> ...
 -- @
-with :: CovariantSig f =>
-  HandleImpl f s ->
-  (forall s0. Handle f s0 -> Eff (s0 :& s) a) ->
-  Eff s a
-with handle action = mergeEff (action (smap useImpl handle))
--- Internally, we just instantiate s0 with s.
+with :: IsHandle f =>
+  f e ->  -- ^ Implementation with effect @e@
+  (forall e0. Handle f e0 -> Eff (e0 :& e) a) ->
+  Eff e a
+with handle action = mergeEff (action (mapHandle handle))
+-- Internally, we just instantiate e0 with e.

--- a/bluefin-internal/src/Bluefin/Internal/Handle.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Handle.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE
+  KindSignatures,
+  RankNTypes,
+  TypeOperators #-}
+
+module Bluefin.Internal.Handle
+  ( -- * Effect signatures
+    Sig
+  , CovariantSig(..)
+
+    -- * Handle usage
+  , Handle
+
+    -- * Handle creation
+  , HandleImpl
+  , with
+  ) where
+
+import Data.Kind (Type)
+import Bluefin.Internal (Eff, mergeEff, useImpl, type (:&), type (:>))
+
+-- | An effect signature declares a set of effectful operations.
+--
+-- Concretely, it should be a record of functions parameterized by a monad
+-- which occurs in the codomain of every field.
+--
+-- A handle of signature @f@ can be defined simply as a value of type @f (Eff s)@.
+-- But to use it, a handle will have type @'Handle' f@ so that its operations
+-- can be invoked with different effect rows in 'Eff', as long as they contain
+-- the row @s@ in the type of its original definition @f (Eff s)@.
+-- See 'Handle' and 'with' for more detaills.
+--
+-- === Example
+--
+-- Effect with the two state operations @get@ and @put@:
+--
+-- @
+-- type State :: Type -> 'Sig'
+-- data State s m = MkState
+--   { get :: m s
+--   , put :: s -> m ()
+--   }
+-- @
+type Sig = (Type -> Type) -> Type
+
+-- | Effect signatures must be instances of this class: they are higher-order functors.
+class CovariantSig (f :: Sig) where
+  smap :: (forall x. m x -> n x) -> f m -> f n
+
+-- | Handle of signature @f@ that can be used in an effectful computation @'Eff' s1@,
+-- given a constraint @s :> s1@.
+--
+-- === Example
+--
+-- Given a handle @h@ of type @'Handle' f s0@, you can invoke its operations as
+-- @get h@ and @put h@, or @h.get@ and @h.put@ by using the extension
+-- @OverloadedRecordDot@.
+--
+-- Indeed, thanks to the polymorphism in 'Handle', the field accessors can be specialized
+-- to the following types:
+--
+-- @
+-- get :: z0 :> z => 'Handle' (State s) z0 -> 'Eff' z s
+-- put :: z0 :> z => 'Handle' (State s) z0 -> s -> 'Eff' z ()
+-- @
+type Handle f s = (forall s1. s :> s1 => f (Eff s1))
+
+-- | Handle implementation of signature @f@.
+type HandleImpl f s = f (Eff s)
+
+-- | Create a 'Handle' @h@ with signature @f@, using the given implementation @impl@.
+--
+-- @
+-- 'with' impl \\h -> ...
+-- @
+with :: CovariantSig f =>
+  HandleImpl f s ->
+  (forall s0. Handle f s0 -> Eff (s0 :& s) a) ->
+  Eff s a
+with handle action = mergeEff (action (smap useImpl handle))
+-- Internally, we just instantiate s0 with s.

--- a/bluefin-internal/src/Bluefin/Internal/Handle.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Handle.hs
@@ -11,6 +11,7 @@ module Bluefin.Internal.Handle
 
     -- * Handle creation
     with,
+    within,
   )
 where
 
@@ -18,6 +19,7 @@ import Bluefin.Internal
   ( Eff,
     Effects,
     IsHandle (..),
+    insertManySecond,
     mergeEff,
     type (:&),
     type (:>),
@@ -80,3 +82,18 @@ with ::
 with handle action = mergeEff (action (mapHandle handle))
 
 -- Internally, we just instantiate e0 with e.
+
+within ::
+  (IsHandle f, e :> es) =>
+  (forall e0. Handle f e0 -> Eff (e0 :& e) r) ->
+  f es ->
+  Eff es r
+within k fsh0 = with fsh0 (useImplWithin k)
+
+-- Like useImplIn
+useImplWithin ::
+  (e :> es) =>
+  (Handle f e1 -> Eff (e1 :& e) r) ->
+  Handle f e1 ->
+  Eff (e1 :& es) r
+useImplWithin k fsh = insertManySecond (k fsh)

--- a/bluefin-internal/test/Main.hs
+++ b/bluefin-internal/test/Main.hs
@@ -4,7 +4,7 @@
 module Main (main) where
 
 import Bluefin.Internal
-import Bluefin.Internal.Handle (CovariantSig(..), with)
+import Bluefin.Internal.Handle (with)
 import qualified Bluefin.Internal.Handle as H
 import Control.Monad (when)
 import Data.Foldable (for_)
@@ -154,10 +154,10 @@ listEff (as, r) y = do
   pure r
 
 -- Test custom handles
-data MyReader r m = MkMyReader { myAsk :: m r }
+data MyReader r e = MkMyReader { myAsk :: Eff e r }
 
-instance CovariantSig (MyReader r) where
-  smap f h = MkMyReader { myAsk = f (myAsk h) }
+instance IsHandle (MyReader r) where
+  mapHandle h = MkMyReader { myAsk = useImpl (myAsk h) }
 
-runMyReader :: r -> (forall s0. H.Handle (MyReader r) s0 -> Eff (s0 :& s) a) -> Eff s a
+runMyReader :: r -> (forall e0. H.Handle (MyReader r) e0 -> Eff (e0 :& e) a) -> Eff e a
 runMyReader r = with (MkMyReader { myAsk = pure r })

--- a/bluefin/bluefin.cabal
+++ b/bluefin/bluefin.cabal
@@ -26,6 +26,7 @@ library
       Bluefin.EarlyReturn,
       Bluefin.Eff,
       Bluefin.Exception,
+      Bluefin.Handle,
       Bluefin.IO,
       Bluefin.Jump,
       Bluefin.Reader,

--- a/bluefin/src/Bluefin/Compound.hs
+++ b/bluefin/src/Bluefin/Compound.hs
@@ -455,7 +455,7 @@ module Bluefin.Compound
 
     -- * Functions for making compound effects
 
-    Handle (mapHandle),
+    IsHandle (mapHandle),
     useImpl,
     useImplIn,
 

--- a/bluefin/src/Bluefin/Handle.hs
+++ b/bluefin/src/Bluefin/Handle.hs
@@ -1,0 +1,18 @@
+-- | = Custom handles
+--
+-- Create Bluefin effects with your own types of handles.
+
+module Bluefin.Handle
+  ( -- * Effect signatures
+    Sig
+  , CovariantSig(..)
+
+    -- * Handle types
+  , HandleImpl
+  , Handle
+
+    -- * Handle creation
+  , with
+  ) where
+
+import Bluefin.Internal.Handle

--- a/bluefin/src/Bluefin/Handle.hs
+++ b/bluefin/src/Bluefin/Handle.hs
@@ -5,10 +5,8 @@
 module Bluefin.Handle
   ( -- * Effect signatures
     Sig
-  , CovariantSig(..)
 
     -- * Handle types
-  , HandleImpl
   , Handle
 
     -- * Handle creation


### PR DESCRIPTION
Based on your suggestion on the cleff issue tracker https://github.com/re-xyr/cleff/issues/31

I mainly wanted to show an implementation that allows the record field selectors to be used directly, so you don't need to declare operations as separate functions.

I specialized the name of the `CovariantSig` class, but of course it's just one of those `HFunctor` elsewhere.

As I mentioned on Discourse, this is an interface that is forwards-compatible with algebraic effects while being hopefully useful on its own as a restricted form of effect handlers  ("tail-resumptive"). In effectful-core, this corresponds to the `Dispatch.Static` module.

I tried to avoid the word "handler" (which can be too easily overloaded), instead sticking to the word "handle" as in "handle-pattern".