### PR TITLE
`Cont` effect.

### DIFF
--- a/bluefin-examples/bluefin-examples.cabal
+++ b/bluefin-examples/bluefin-examples.cabal
@@ -75,6 +75,7 @@ common warnings
 library
     import:           warnings
     exposed-modules:
+      Bluefin.Examples.Cont,
       Bluefin.Examples.DB,
       Bluefin.Examples.Stream.InsideAndOut,
       Bluefin.Examples.Stream.Many,

--- a/bluefin-examples/src/Bluefin/Examples/Cont.hs
+++ b/bluefin-examples/src/Bluefin/Examples/Cont.hs
@@ -13,7 +13,7 @@ f = runEff $ \io -> do
     s1 <- new eff $ evalState 5
     s2 <- new eff $ evalState 10
     liftEff eff $ do
-      put s1 10
-      put s2 15
+      s <- get s1
+      modify s2 (+ s)
       hPutStr h "hello world"
       get s2

--- a/bluefin-examples/src/Bluefin/Examples/Cont.hs
+++ b/bluefin-examples/src/Bluefin/Examples/Cont.hs
@@ -1,0 +1,19 @@
+module Bluefin.Examples.Cont where
+
+import Bluefin.Cont
+import Bluefin.IO (runEff)
+import Bluefin.State
+import Bluefin.System.IO (hPutStr, withFile)
+import System.IO (IOMode (ReadMode))
+
+f :: IO Integer
+f = runEff $ \io -> do
+  runCont $ \eff -> do
+    h <- new eff $ withFile io "file.txt" ReadMode
+    s1 <- new eff $ evalState 5
+    s2 <- new eff $ evalState 10
+    liftEff eff $ do
+      put s1 10
+      put s2 15
+      hPutStr h "hello world"
+      get s2

--- a/bluefin-examples/src/Bluefin/Examples/Cont.hs
+++ b/bluefin-examples/src/Bluefin/Examples/Cont.hs
@@ -5,6 +5,9 @@ import Bluefin.IO (runEff)
 import Bluefin.State
 import Bluefin.System.IO (hPutStr, withFile)
 import System.IO (IOMode (ReadMode))
+import Bluefin.Eff (runPureEff)
+import Data.Traversable (for)
+import Data.Foldable (for_)
 
 f :: IO Integer
 f = runEff $ \io -> do
@@ -17,3 +20,16 @@ f = runEff $ \io -> do
       modify s2 (+ s)
       hPutStr h "hello world"
       get s2
+
+g :: Integer
+g = runPureEff $ do
+  runCont $ \eff -> do
+    total <- new eff $ evalState 0
+    states <- for [1..10] $ \i -> do
+      new eff $ evalState i
+    liftEff eff $ do
+      for_ states $ \state -> do
+        v <- get state
+        modify total (+ v)
+      get total
+  

--- a/bluefin-internal/bluefin-internal.cabal
+++ b/bluefin-internal/bluefin-internal.cabal
@@ -86,6 +86,7 @@ library
     ghc-options: -Wall
     exposed-modules:
       Bluefin.Internal,
+      Bluefin.Internal.Cont,
       Bluefin.Internal.Examples,
       Bluefin.Internal.Pipes,
       Bluefin.Internal.System.IO

--- a/bluefin-internal/src/Bluefin/Internal/Cont.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Cont.hs
@@ -3,7 +3,6 @@
 module Bluefin.Internal.Cont where
 
 import Bluefin.Internal (Eff, Effects, useImplIn, (:&), (:>))
-import System.IO.Unsafe (unsafePerformIO)
 import Unsafe.Coerce (unsafeCoerce)
 
 newtype EffCont r m a = MkEffCont {unEffCont :: (a -> m r) -> m r}

--- a/bluefin-internal/src/Bluefin/Internal/Cont.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Cont.hs
@@ -2,7 +2,7 @@
 
 module Bluefin.Internal.Cont where
 
-import Bluefin.Internal (Eff, Effects, useImplIn, (:&))
+import Bluefin.Internal (Eff, Effects, useImplIn, (:&), (:>))
 import System.IO.Unsafe (unsafePerformIO)
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -34,6 +34,7 @@ runCont f = unsafeRunCont $ \cont -> do
     unsafeRunCont c = useImplIn c UnsafeMkCont
 
 liftEff ::
+  (contE :> es) =>
   Cont contE ->
   Eff es a ->
   EffCont r (Eff es) a

--- a/bluefin-internal/src/Bluefin/Internal/Cont.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Cont.hs
@@ -5,24 +5,24 @@ module Bluefin.Internal.Cont where
 import Bluefin.Internal (Eff, Effects, useImplIn, (:&), (:>))
 import Unsafe.Coerce (unsafeCoerce)
 
-newtype EffCont r m a = MkEffCont {unEffCont :: (a -> m r) -> m r}
+newtype EffCont es a = MkEffCont {unEffCont :: forall r. (a -> Eff es r) -> Eff es r}
 
-instance Functor (EffCont r m) where
+instance Functor (EffCont es) where
   fmap f m = MkEffCont $ \c -> unEffCont m (c . f)
 
-instance Applicative (EffCont r m) where
+instance Applicative (EffCont es) where
   pure x = MkEffCont ($ x)
   f <*> v = MkEffCont $ \c -> unEffCont f $ \g -> unEffCont v (c . g)
   m *> k = m >> k
 
-instance Monad (EffCont r m) where
+instance Monad (EffCont es) where
   return = pure
   m >>= k = MkEffCont $ \c -> unEffCont m (\x -> unEffCont (k x) c)
 
 data Cont (e :: Effects) = UnsafeMkCont
 
 runCont ::
-  (forall e. Cont e -> EffCont a (Eff (e :& es)) a) ->
+  (forall e. Cont e -> EffCont (e :& es) a) ->
   Eff es a
 runCont f = unsafeRunCont $ \cont -> do
   unEffCont (f cont) return
@@ -36,17 +36,17 @@ liftEff ::
   (contE :> es) =>
   Cont contE ->
   Eff es a ->
-  EffCont r (Eff es) a
+  EffCont es a
 liftEff _ f = MkEffCont $ \effCont -> f >>= effCont
 
 new ::
   Cont contE ->
   ((forall (e :: Effects). f e -> Eff (e :& es) r) -> Eff es r) ->
-  EffCont r (Eff (contE :& es)) (f contE)
+  EffCont (contE :& es) (f contE)
 new f = MkEffCont . forceEffTag f
   where
     forceEffTag ::
       Cont contE ->
-      ((forall e. f e -> Eff (e :& es) r) -> Eff es r) ->
-      ((f contE -> Eff (contE :& es) r) -> Eff (contE :& es) r)
+      ((forall e. f e -> Eff (e :& es) a) -> Eff es a) ->
+      (forall r. (f contE -> Eff (contE :& es) r) -> Eff (contE :& es) r)
     forceEffTag _ = unsafeCoerce

--- a/bluefin-internal/src/Bluefin/Internal/Cont.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Cont.hs
@@ -37,7 +37,7 @@ liftEff ::
   Cont contE ->
   Eff es a ->
   EffCont r (Eff es) a
-liftEff _ f = MkEffCont $ \cont -> f >>= cont
+liftEff _ f = MkEffCont $ \effCont -> f >>= effCont
 
 new ::
   Cont contE ->

--- a/bluefin-internal/src/Bluefin/Internal/Cont.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Cont.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE ImpredicativeTypes #-}
+
+module Bluefin.Internal.Cont where
+
+import Bluefin.Internal (Eff, Effects, unsafeUnEff, useImplIn, (:&))
+import System.IO.Unsafe (unsafePerformIO)
+import Unsafe.Coerce (unsafeCoerce)
+
+newtype EffCont r m a = MkEffCont {unEffCont :: (a -> m r) -> m r}
+
+instance Functor (EffCont r m) where
+  fmap f m = MkEffCont $ \c -> unEffCont m (c . f)
+
+instance Applicative (EffCont r m) where
+  pure x = MkEffCont ($ x)
+  f <*> v = MkEffCont $ \c -> unEffCont f $ \g -> unEffCont v (c . g)
+  m *> k = m >> k
+
+instance Monad (EffCont r m) where
+  return = pure
+  m >>= k = MkEffCont $ \c -> unEffCont m (\x -> unEffCont (k x) c)
+
+data Cont (e :: Effects) = UnsafeMkCont
+
+runCont ::
+  (forall e. Cont e -> EffCont a (Eff (e :& es)) a) ->
+  Eff es a
+runCont f = unsafeRunCont $ \eff -> do
+  unEffCont (f eff) return
+  where
+    unsafeRunCont ::
+      (forall e. Cont e -> Eff (e :& es) a) ->
+      Eff es a
+    unsafeRunCont c = useImplIn c UnsafeMkCont
+
+liftEff ::
+  Cont newE ->
+  Eff es a ->
+  EffCont r (Eff es) a
+liftEff _ = return . unsafePerformIO . unsafeUnEff
+
+new ::
+  Cont newE ->
+  ((forall (e :: Effects). f e -> Eff (e :& es) r) -> Eff es r) ->
+  EffCont r (Eff (newE :& es)) (f newE)
+new f = MkEffCont . forceEffTag f
+  where
+    forceEffTag ::
+      Cont newE ->
+      ((forall e. f e -> Eff (e :& es) r) -> Eff es r) ->
+      ((f1 newE -> Eff (newE :& es) r) -> Eff (newE :& es) r)
+    forceEffTag _ = unsafeCoerce

--- a/bluefin-internal/src/Bluefin/Internal/Cont.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Cont.hs
@@ -2,6 +2,7 @@
 
 module Bluefin.Internal.Cont where
 
+import Bluefin.Eff ((:>))
 import Bluefin.Internal (Eff, Effects, unsafeUnEff, useImplIn, (:&))
 import System.IO.Unsafe (unsafePerformIO)
 import Unsafe.Coerce (unsafeCoerce)
@@ -37,7 +38,7 @@ liftEff ::
   Cont newE ->
   Eff es a ->
   EffCont r (Eff es) a
-liftEff _ = return . unsafePerformIO . unsafeUnEff
+liftEff _ f = MkEffCont $ \cont -> f >>= cont
 
 new ::
   Cont newE ->

--- a/bluefin/bluefin.cabal
+++ b/bluefin/bluefin.cabal
@@ -23,6 +23,7 @@ library
       Bluefin,
       Bluefin.Compound,
       Bluefin.Consume,
+      Bluefin.Cont,
       Bluefin.Coroutine,
       Bluefin.EarlyReturn,
       Bluefin.Eff,

--- a/bluefin/src/Bluefin/Cont.hs
+++ b/bluefin/src/Bluefin/Cont.hs
@@ -1,0 +1,10 @@
+module Bluefin.Cont
+  ( EffCont,
+    Cont,
+    runCont,
+    liftEff,
+    new,
+  )
+where
+
+import Bluefin.Internal.Cont


### PR DESCRIPTION
resolves #42 

Indeed, my approach was trying to implement a special case of something that cont monad generalizes nicely. So let's do a cont monad instead.

Unfortunately, I don't think we can make a proper monad out of this.

 ```haskell
unEffCont :: (forall e. a e -> Eff (e :& es) r) -> Eff es r
```

So I went with a favorite of mine: `unsafeCoerce`. It requires `ImpredicativeTypes`, no idea if that is a problem.

Overall, it looks promising. I really don't like the monad instance, thought. It is polymorphic in `m` for no other reason than me failing to implement/derive it for `Eff`.

Other than that, names are rather random. `new` is too general, and so is `liftEff` (I almost want to make it better to be imported qualified, but other parts of the library don't do that).

I plan to do some benchmarks of this, but for now it is ready enough to test things out.