### PR TITLE
Add Bluefin.Internal.With (QualifiedDo support for avoiding nesting)

### DIFF
--- a/bluefin-internal/bluefin-internal.cabal
+++ b/bluefin-internal/bluefin-internal.cabal
@@ -88,7 +88,8 @@ library
       Bluefin.Internal,
       Bluefin.Internal.Examples,
       Bluefin.Internal.Pipes,
-      Bluefin.Internal.System.IO
+      Bluefin.Internal.System.IO,
+      Bluefin.Internal.With
 
 test-suite bluefin-test
     import:           defaults

--- a/bluefin-internal/src/Bluefin/Internal/With.hs
+++ b/bluefin-internal/src/Bluefin/Internal/With.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE QualifiedDo #-}
+
+module Bluefin.Internal.With where
+
+import Data.Foldable (for_)
+import Data.Traversable (for)
+import Bluefin.Internal
+import Bluefin.Internal.System.IO (hPutStr, withFile, IOMode (ReadMode))
+
+-- This is `id` if you allow impredicative types
+(>>=) ::
+  ((forall e. f e -> Eff (e :& es) a) -> Eff es a) ->
+  (forall e. f e -> Eff (e :& es) a) ->
+  Eff es a
+(>>=) handler = handler
+
+f :: IO Integer
+f = runEff $ \io -> do
+  Bluefin.Internal.With.do
+    h <- withFile io "file.txt" ReadMode
+    s1 <- evalState 5
+    s2 <- evalState 10
+    do
+      s <- get s1
+      modify s2 (+ s)
+      hPutStr h "hello world"
+      get s2
+
+{-
+g :: Integer
+g = runPureEff $ do
+  Bluefin.Internal.With.do
+    total <- evalState 0
+    -- Don't think we can do this with QualifiedDo
+    states <- for [1..10] $ \i -> do
+      evalState i
+    do
+      for_ states $ \state -> do
+        v <- get state
+        modify total (+ v)
+      get total
+-}


### PR DESCRIPTION
Potential solution to https://github.com/tomjaguarpaw/bluefin/issues/42, alternative to https://github.com/tomjaguarpaw/bluefin/pull/43.

Unfortunately, it panics GHC before 9.10.