### PR TITLE
Add `useImplIn2`.

### DIFF
--- a/bluefin-internal/src/Bluefin/Internal.hs
+++ b/bluefin-internal/src/Bluefin/Internal.hs
@@ -314,6 +314,16 @@ useImplIn ::
   Eff es r
 useImplIn f h = inContext (f h)
 
+-- | Used to define handlers of compound effects with two arguments.
+useImplIn2 ::
+  (e :> es) =>
+  (t1 -> t2 -> Eff (es :& e) r) ->
+  t1 ->
+  t2 ->
+  -- | ͘
+  Eff es r
+useImplIn2 f h1 h2 = inContext (f h1 h2)
+
 -- | Deprecated.  Use 'useImplUnder' instead.
 useImplWithin ::
   (e :> es) =>

--- a/bluefin-internal/src/Bluefin/Internal/Examples.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Examples.hs
@@ -1068,3 +1068,47 @@ runDynamicReader r k =
         { askLRImpl = ask h,
           localLRImpl = \f k' -> makeOp (local h f (useImpl k'))
         }
+
+data Spin e = UnsafeMkSpin
+  { io :: IOE e,
+    spin :: State (Maybe Bool) e,
+    isOther :: Bool
+  }
+
+runEntangled ::
+  (e1 :> es) =>
+  IOE e1 ->
+  (forall e. Spin e -> Spin e -> Eff (e :& es) r) ->
+  Eff es r
+runEntangled io act = evalState Nothing $ \s -> do
+  let s1 = UnsafeMkSpin (mapHandle io) (mapHandle s) False
+  let s2 = UnsafeMkSpin (mapHandle io) (mapHandle s) True
+  useImplIn2 act s1 s2
+
+measure ::
+  (e :> es) =>
+  Spin e ->
+  Eff es Bool
+measure (UnsafeMkSpin io mbSpin isOther) = do
+  get mbSpin >>= \case
+    Just spin -> pure $ if isOther then not spin else spin
+    Nothing -> do
+      spin <- effIO io fakeRandomBool
+      put mbSpin (Just spin)
+      pure $ if isOther then not spin else spin
+  where
+    fakeRandomBool :: IO Bool
+    fakeRandomBool = pure True
+
+useImplIn2example :: IO (Either String String)
+useImplIn2example = runEff_ $ \io -> do
+  try $ \ex -> do
+    for_ (take 10 (cycle [True, False])) $ \whoFirst -> do
+      runEntangled io $ \alice bob -> do
+        (r1, r2) <-
+          if whoFirst
+            then liftA2 (,) (measure alice) (measure bob)
+            else liftA2 (,) (measure bob) (measure alice)
+        when (r1 == r2) $ do
+          throw ex "the universe is broken"
+    pure "all good"

--- a/bluefin-internal/src/Bluefin/Internal/Examples.hs
+++ b/bluefin-internal/src/Bluefin/Internal/Examples.hs
@@ -1107,8 +1107,14 @@ useImplIn2example = runEff_ $ \io -> do
       runEntangled io $ \alice bob -> do
         (r1, r2) <-
           if whoFirst
-            then liftA2 (,) (measure alice) (measure bob)
-            else liftA2 (,) (measure bob) (measure alice)
+            then do
+              ra <- measure alice
+              rb <- measure bob
+              pure (ra, rb)
+            else do
+              rb <- measure bob
+              ra <- measure alice
+              pure (rb, ra)
         when (r1 == r2) $ do
           throw ex "the universe is broken"
     pure "all good"

--- a/bluefin/src/Bluefin/Compound.hs
+++ b/bluefin/src/Bluefin/Compound.hs
@@ -662,6 +662,7 @@ module Bluefin.Compound
     useImpl,
     useImplUnder,
     useImplIn,
+    useImplIn2,
 
     -- * Deprecated
 


### PR DESCRIPTION
Yes, a tuple would do here. But I like this more. The example is silly, but it's just to confirm it works. My real example is something like this.

```haskell
data BroadcastClient a e = UnsafeMkBroadcastClient
    { ioe :: IOE e
    , inChan :: InChan a
    }

data BroadcastServer a e = UnsafeMkBroadcastServer
    { ioe :: IOE e
    , inChan :: InChan a
    }

runBroadcast
    :: (e1 :> es)
    => IOE e1
    -> (forall e. BroadcastClient a e -> BroadcastServer a e -> Eff (e :& es) r)
    -> Eff es r
...
```

It requires concurrency to work, so I can't put it in _yet_.

There are `useImpl*` friends that might need the same treatment, but I don't have a use case, so I let them be.