### PR TITLE
Add runManyStates

### DIFF
--- a/bluefin-internal/src/Bluefin/Internal.hs
+++ b/bluefin-internal/src/Bluefin/Internal.hs
@@ -750,6 +750,27 @@ runState s f = do
     s' <- get state
     pure (a, s')
 
+-- |
+-- @
+-- >>> runPureEff $ runManyStates [10,15,20] $ mapM
+--       (\st -> do
+--          n <- get st
+--          pure (2 * n)
+--       )
+-- ([20,30,40],[10,15,20])
+-- @
+runManyStates
+  :: Traversable t
+  => t s
+  -> (forall (e :: Effects). t (State s e) -> Eff (e :& es) a)
+  -> Eff es (a, t s)
+runManyStates ss f =
+  withStateSource $ \source -> do
+    states <- traverse (newState source) ss
+    a <- f states
+    ss' <- traverse get states
+    pure (a, ss')
+
 yieldCoroutine ::
   (e1 :> es) =>
   Coroutine a b e1 ->

--- a/bluefin/src/Bluefin/State.hs
+++ b/bluefin/src/Bluefin/State.hs
@@ -4,6 +4,7 @@ module Bluefin.State
     -- * Handlers
     evalState,
     runState,
+    runManyStates,
     withState,
     -- * Effectful operations
     get,


### PR DESCRIPTION
For your consideration. I needed this function in my project. `runState` could have been implemented with `runManyStates` by using `Identity` internally but I left that out.

I think this could use a bit of more documentation of its use. It won't work straight away with `useImplIn` but it'd need something like
```
runManyStores sts k =
  useImplIn
    k $
    fmap
    (\st -> ...)
    sts
```
which may not be immediately obvious. I'd have included it but I thought to ask about a good place for it.