### PR TITLE
Add MonadFix instance for Eff

### DIFF
--- a/bluefin-internal/src/Bluefin/Internal.hs
+++ b/bluefin-internal/src/Bluefin/Internal.hs
@@ -26,6 +26,7 @@ import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Exception qualified
 import Control.Monad (forever)
 import Control.Monad.Base (MonadBase (liftBase))
+import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.IO.Unlift (MonadUnliftIO, withRunInIO)
 import Control.Monad.Trans.Control (MonadBaseControl, StM, liftBaseWith, restoreM)
@@ -53,7 +54,7 @@ type (:&) = Union
 
 newtype Eff (es :: Effects) a = UnsafeMkEff {unsafeUnEff :: IO a}
   deriving stock (Functor)
-  deriving newtype (Applicative, Monad)
+  deriving newtype (Applicative, Monad, MonadFix)
 
 type role Eff nominal representational
 


### PR DESCRIPTION
Eff is lacking a MonadFix instance. I don't think there are any bad effects from adding it, since Bluefin is just wrapping IO in the end? The example below from the Haskell Wiki works fine:

```
import Bluefin.Internal (Eff(..))
import GHC.IO (IO(..))
import Data.IORef
import Bluefin.IO
import Bluefin.Eff
import Control.Monad.Fix

deriving newtype instance MonadFix (Eff es)

data Node = Node Int (IORef Node)

mknode :: (e :> es) => IOE e -> Eff es (IORef Node)
mknode io = mdo
  p <- effIO io (newIORef (Node 0 p))
  effIO io $ putStrLn "node created"
  return p

main = runEff $ \io -> do
  p <- mknode io
  Node x q <- effIO io $ readIORef p
  effIO io $ print x
  Node y _ <- effIO io $ readIORef q
  effIO io $ print y
```